### PR TITLE
use grep to exclude GPG_PASSPHRASE when printing environment variables

### DIFF
--- a/recipes/_environment.rb
+++ b/recipes/_environment.rb
@@ -48,7 +48,7 @@ if windows?
       ECHO ========================================
       ECHO(
 
-      set
+      set | grep -v GPG_PASSPHRASE
 
       REM ###############################################################
       REM # Query tool versions
@@ -133,7 +133,7 @@ if windows?
       Write-Host " = Environment"
       Write-Host " ========================================"
 
-      Get-ChildItem env:
+      Get-ChildItem env: | grep -v GPG_PASSPHRASE
 
       ###############################################################
       # Query tool versions
@@ -201,7 +201,7 @@ else
       echo "========================================"
       echo ""
 
-      env -0 | sort -z | tr '\\0' '\\n'
+      env -0 | sort -z | tr '\\0' '\\n' | grep -v GPG_PASSPHRASE
 
       ###################################################################
       # Query tool versions


### PR DESCRIPTION
### Description

Hotfix preventing GPG_PASSPHRASE value from being leaked into CI logs. Probably needs to be replaced with an implementation which redacts a list of one or more env vars.

### Issues Resolved

Relates to https://github.com/sensu/sensu-omnibus/issues/32
